### PR TITLE
ストロングパラメーターの追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :avatar, :place])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :avatar, :place, :trigger, :future, :now])
+  end
 end


### PR DESCRIPTION
# What
ストロングパラメーターを追加することで、ユーザー登録時に名前、希望の勤務場所、アバターを登録できるようにした。

# Why
デフォルトでは登録できないため。